### PR TITLE
feat: add optional pick key position

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,17 +36,17 @@ to open and close windows within the same **edgebar**.
 - All **edgy** windows require a unique **title** in order to create groups.
 - All **edgy** windows require an **open** command to open each window.
 - Opening a window with a function or command call will not automatically
-switch to the corresponding group.
+  switch to the corresponding group.
 - Switching between groups always sets the cursor to one of the **edgebar**
-windows and does not restore the previous cursor position.
+  windows and does not restore the previous cursor position.
 
 ### Advice
 
 - It is preferable to use at least one **pinned** window with **close_when_all_hidden**
-option set to **false** in order to prevent **edgebar** from "blinking" when switching
-between groups.<br/>
+  option set to **false** in order to prevent **edgebar** from "blinking" when switching
+  between groups.<br/>
   A workaround would be to wait until at least one window is opened before closing
-any existing ones.
+  any existing ones.
 
 ## ⚡️ Requirements
 
@@ -85,7 +85,7 @@ local default_options = {
   statusline = {
     -- suffix and prefix separators between icons
     separators = { ' ', ' ' },
-    clickable = false, -- enable `open_group` on click
+    clickable = false, -- open group on click
     colored = false, -- enable highlight support
     colors = { -- highlight colors
       active = 'Normal', -- highlight color for open group
@@ -93,6 +93,11 @@ local default_options = {
       pick_active = 'PmenuSel', -- highlight color for pick key for open group
       pick_inactive = 'PmenuSel', -- highlight color for pick key for closed group
     },
+    -- pick key position: left, right, left_separator, right_separator, icon
+    -- left: before left separator
+    -- right: after right separator
+    -- left_separator, right_separator and icon: replace the corresponding element
+    pick_key_pose = 'left',
   },
   toggle = true, -- toggle group when at least one window is already open
 }
@@ -120,13 +125,13 @@ Groups without pick_key will be assigned to the first available key in alphabeti
 - **EdgyGroupNext position** open next group at given position.
 - **EdgyGroupPrev position** open previous group at given position.
 - **require('edgy-group').open_group_offset(position, offset)**
-open group with offset relative to the current group.
+  open group with offset relative to the current group.
 - **require('edgy-group').open_group_index(position, index)**
-open group with index relative to the current position.
+  open group with index relative to the current position.
 - **require('edgy-group.stl.statusline').get_statusline(position)** get a list of string
-in statusline format for each group icons with optional highlight and click support.
+  in statusline format for each group icons with optional highlight and click support.
 - **require('edgy-group.stl.statusline').pick(callback)**
-enable picking mode to select group from statusline.
+  enable picking mode to select group from statusline.
 
 ## Example Setup
 
@@ -140,7 +145,7 @@ Usage of **edgy-group.nvim** to create three groups for the left **edgebar**:
 {
   "lucobellic/edgy-group.nvim",
   event = "VeryLazy"
-  dependencies = {"folke/edgy.nvim"}
+  dependencies = { "folke/edgy.nvim" },
   keys = {
     {
       '<leader>el',
@@ -179,12 +184,48 @@ Usage of **edgy-group.nvim** to create three groups for the left **edgebar**:
     },
   }
 }
+
+-- edgy configuration (simplified)
+{
+  "folke/edgy.nvim",
+  -- ...
+  opts = {
+    -- ...
+    left = {
+      {
+        title = "Neo-Tree",
+        ft = "neo-tree",
+        filter = function(buf) return vim.b[buf].neo_tree_source == "filesystem" end,
+        size = { height = 0.5 },
+      },
+      {
+        title = "Neo-Tree Buffers",
+        ft = "neo-tree",
+        filter = function(buf) return vim.b[buf].neo_tree_source == "buffers" end,
+        open = "Neotree position=top buffers",
+      },
+      {
+        title = "Neo-Tree Git",
+        ft = "neo-tree",
+        filter = function(buf) return vim.b[buf].neo_tree_source == "git_status" end,
+        open = "Neotree position=right git_status",
+      },
+      {
+        ft = "Outline",
+        open = "SymbolsOutlineOpen",
+      },
+    },
+  },
+}
 ```
 
 ### Statusline
 
-Examples of how to use **edgy-group.nvim** with [bufferline.nvim](https://github.com/akinsho/bufferline.nvim)
-and [lualine.nvim](https://github.com/nvim-lualine/lualine.nvim) to add group icons with highlight and click support.
+Examples of how to use **edgy-group.nvim** with
+[bufferline.nvim](https://github.com/akinsho/bufferline.nvim),
+[lualine.nvim](https://github.com/nvim-lualine/lualine.nvim),
+[heirline.nvim](https://github.com/rebelot/heirline.nvim)
+to add group icons with highlight and click support.
 
 #### Bufferline
 
@@ -227,6 +268,18 @@ and [lualine.nvim](https://github.com/nvim-lualine/lualine.nvim) to add group ic
       },
     },
   },
+}
+```
+
+#### Heirline
+
+``` lua
+local EdgyGroup = {
+  provider = function()
+    local stl = require('edgy-group.stl.statusline')
+    local bottom_line = stl.get_statusline('bottom')
+    return table.concat(bottom_line)
+  end
 }
 ```
 

--- a/lua/edgy-group/config.lua
+++ b/lua/edgy-group/config.lua
@@ -7,11 +7,19 @@ local Groups = require('edgy-group.groups')
 ---@field titles string[] list of titles from edgy.nvim
 ---@field pick_key? string Key to use for group pick
 
+---@alias EdgyGroup.PickKeyPose
+---| '"left"' # pick key at the left of the icon, before separators
+---| '"right"' # pick key at the right of the icon, after separators
+---| '"left_separator"' # replace the left separator
+---| '"right_separator"' # replace the right separator
+---| '"icon"' # replace group icon
+
 ---@class EdgyGroup.Statusline.Opts
 ---@field separators { [1]: string, [2]: string } suffix and prefix separators between icons
 ---@field clickable boolean enable `open_group` on click
 ---@field colored boolean enable highlighting support
 ---@field colors EdgyGroup.Statusline.Colors highlight colors for icon and pick key
+---@field pick_key_pose EdgyGroup.PickKeyPose position of the pick key, which could replace the icon or the separators
 
 ---@class EdgyGroup.Statusline.Colors
 ---@field active string highlight color for open group
@@ -42,6 +50,7 @@ local default_options = {
       pick_active = 'PmenuSel',
       pick_inactive = 'PmenuSel',
     },
+    pick_key_pose = 'left',
   },
   toggle = true,
 }

--- a/lua/edgy-group/stl/cache.lua
+++ b/lua/edgy-group/stl/cache.lua
@@ -5,9 +5,16 @@
 ---@field position Edgy.Pos
 ---@field index number
 
+---@class EdgyGroup.Statusline.Cache.Line
+---@field callback string
+---@field left_sep string
+---@field icon string
+---@field right_sep string
+---@field end_callback string
+
 ---@class EdgyGroup.Statusline.Cache
 ---@field opts EdgyGroup.Statusline.Opts
----@field status_lines table<Edgy.Pos, string[]>
+---@field statuslines table<Edgy.Pos, EdgyGroup.Statusline.Cache.Line[]>
 ---@field pick_keys table<Edgy.Pos, string[]> pick keys for each position and group
 ---@field key_to_group table<string, EdgyGroup.Statusline.Cache.GroupIndex[]> associates a key with one or multiple groups
 local Cache = {}
@@ -17,7 +24,7 @@ local Cache = {}
 function Cache.new(groups, opts)
   local self = setmetatable({}, { __index = Cache })
   self.opts = opts
-  self.status_lines = self:build_status_lines(groups)
+  self.statuslines = self:build_statuslines(groups)
   self:build_keys(groups)
   return self
 end
@@ -79,30 +86,29 @@ function Cache:get_callback(position, index)
 end
 
 ---@private
----@param group EdgyGroup
-function Cache:get_text(group)
-  return self.opts.separators[1] .. group.icon .. self.opts.separators[2]
-end
-
----@private
 ---@param position Edgy.Pos
 ---@param groups EdgyGroup[]
----@return string[]
+---@return EdgyGroup.Statusline.Cache.Line
 function Cache:build_statusline(position, groups)
   local elements = {}
   for index, group in ipairs(groups or {}) do
     local callback = self:get_callback(position, index)
     local end_callback = self.opts.clickable and '%T' or ''
-    local text = self:get_text(group)
-    table.insert(elements, callback .. text .. end_callback)
+    table.insert(elements, {
+      callback = callback,
+      left_sep = self.opts.separators[1],
+      icon = group.icon,
+      right_sep = self.opts.separators[2],
+      end_callback = end_callback,
+    })
   end
   return elements
 end
 
 ---@private
 ---@param groups table<Edgy.Pos, EdgyGroup.IndexedGroups>
----@return table<Edgy.Pos, string[]>
-function Cache:build_status_lines(groups)
+---@return table<Edgy.Pos, EdgyGroup.Statusline.Cache.Line>
+function Cache:build_statuslines(groups)
   local status_lines = {}
   for _, pos in ipairs({ 'right', 'left', 'bottom', 'top' }) do
     status_lines[pos] = self:build_statusline(pos, groups[pos] and groups[pos].groups or {})

--- a/lua/edgy-group/stl/statusline.lua
+++ b/lua/edgy-group/stl/statusline.lua
@@ -4,13 +4,15 @@ local Group = require('edgy-group')
 ---@class EdgyGroup.Statusline
 ---@field private cache EdgyGroup.Statusline.Cache
 ---@field private pick_mode boolean true when pick is active, false otherwise
-------@diagnostic disable-next-line: missing-fields
+---@field private pick_key_pose EdgyGroup.PickKeyPose
+---@diagnostic disable-next-line: missing-fields
 local M = {}
 
 ---@param groups table<Edgy.Pos, EdgyGroup.IndexedGroups>
 ---@param opts EdgyGroup.Statusline.Opts
 function M.setup(groups, opts)
   M.cache = require('edgy-group.stl.cache').new(groups, opts)
+  M.pick_key_pose = opts.pick_key_pose
   M.pick_mode = false
 end
 
@@ -37,6 +39,45 @@ function M.get_pick_text(is_visible, position, index)
   return pick
 end
 
+---@alias EdgyGroup.PickStatusLine function(pick: string, highlight: string, line: EdgyGroup.Statusline.Cache.Elements): string
+
+-- Table of statusline with pick key at different position
+---@private
+---@type table<EdgyGroup.PickKeyPose, EdgyGroup.PickStatusLine>
+local line_with_pick = {
+  left = function(pick, highlight, line)
+    return pick .. highlight .. line.left_sep .. line.icon .. line.right_sep
+  end,
+  left_separator = function(pick, highlight, line)
+    return pick .. highlight .. line.icon .. line.right_sep
+  end,
+  icon = function(pick, highlight, line)
+    return highlight .. line.left_sep .. pick .. highlight .. line.right_sep
+  end,
+  right_separator = function(pick, highlight, line)
+    return highlight .. line.left_sep .. line.icon .. pick
+  end,
+  right = function(pick, highlight, line)
+    return highlight .. line.left_sep .. line.icon .. line.right_sep .. pick
+  end,
+}
+
+-- Get the statusline icon with optional pick key at different position
+---@private
+---@param pick string
+---@param highlight string
+---@param line EdgyGroup.Statusline.Cache.Elements
+---@return string statusline_icon
+function M.get_statusline_icon(pick, highlight, line)
+  -- PERF: build in cache for all possible pick modes
+  if not M.pick_mode then
+    return highlight .. line.callback .. line.left_sep .. line.icon .. line.right_sep .. line.end_callback
+  end
+  -- Get the statusline for the pick key position, default to left
+  local get_line_with_pick = line_with_pick[M.pick_key_pose] or line_with_pick['left']
+  return get_line_with_pick(pick, highlight, line)
+end
+
 -- Get a list of statusline at the given position for each group icons
 -- Also provide optional highlight and click support
 ---@public
@@ -47,11 +88,12 @@ function M.get_statusline(position)
   local edgebar = Config and Config.layout and Config.layout[position]
   local indexed_groups = Group.groups_by_pos and Group.groups_by_pos[position]
   if edgebar and indexed_groups then
-    for index, group_line in ipairs(M.cache.status_lines[position]) do
+    for index, line in ipairs(M.cache.statuslines[position]) do
       local is_visible = edgebar.visible ~= 0 and index == indexed_groups.selected_index
       local highlight = M.get_highlight(is_visible)
       local pick = M.get_pick_text(is_visible, position, index)
-      table.insert(statusline, pick .. highlight .. group_line)
+      -- if pick is enabled, replace the left separator by the pick key
+      table.insert(statusline, M.get_statusline_icon(pick, highlight, line))
     end
   end
   return statusline


### PR DESCRIPTION
Add 5 pick key positions: left, right, left_separator, right_separator, icon.

The pick key will replace the left and right separator or icon if set to the corresponding option.