### PR TITLE
feat: remove error for group without open command

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,14 +54,6 @@ to open and close windows within the same **edgebar**.
 - Switching between groups always sets the cursor to one of the **edgebar**
   windows and does not restore the previous cursor position.
 
-### Advice
-
-- It is preferable to use at least one **pinned** window with **close_when_all_hidden**
-  option set to **false** in order to prevent **edgebar** from "blinking" when switching
-  between groups.  
-  A workaround would be to wait until at least one window is opened before closing
-  any existing ones.
-
 ## ⚡️ Requirements
 
 [edgy.nvim](https://github.com/folke/edgy.nvim)

--- a/README.md
+++ b/README.md
@@ -51,8 +51,6 @@ to open and close windows within the same **edgebar**.
 - All **edgy** windows require a unique **title** in order to create groups.
 - Opening a window with a function or command call will not automatically
   switch to the corresponding group.
-- Switching between groups always sets the cursor to one of the **edgebar**
-  windows and does not restore the previous cursor position.
 
 ## ⚡️ Requirements
 

--- a/README.md
+++ b/README.md
@@ -49,7 +49,6 @@ It is a simple wrapper around **edgy.nvim** that is used
 to open and close windows within the same **edgebar**.
 
 - All **edgy** windows require a unique **title** in order to create groups.
-- All **edgy** windows require an **open** command to open each window.
 - Opening a window with a function or command call will not automatically
   switch to the corresponding group.
 - Switching between groups always sets the cursor to one of the **edgebar**

--- a/lua/edgy-group/init.lua
+++ b/lua/edgy-group/init.lua
@@ -55,8 +55,6 @@ local function open(view)
     Util.try(function()
       vim.cmd(view.open)
     end)
-  else
-    Util.error('View is pinned and has no open function')
   end
 end
 


### PR DESCRIPTION
Update documentation and remove unnecessary error on group without open command.

Removing the error remove the need to add pointless `open = ''` in edgy